### PR TITLE
Allow custom PropType classes with no-typos rule

### DIFF
--- a/docs/rules/prefer-stateless-function.md
+++ b/docs/rules/prefer-stateless-function.md
@@ -11,6 +11,7 @@ This rule will check your class based React components for
 * extension of `React.PureComponent` (if the `ignorePureComponents` flag is true)
 * presence of `ref` attribute in JSX
 * the use of decorators
+* methods inside a React Component that return JSX other than the `render()` method (if the `subRenderMethods` flag is true)
 * `render` method that return anything but JSX: `undefined`, `null`, etc. (only in React <15.0.0, see [shared settings](https://github.com/yannickcr/eslint-plugin-react/blob/master/README.md#configuration) for React version configuration)
 
 If none of these elements are found, the rule will warn you to write this component as a pure function.
@@ -55,12 +56,13 @@ class Foo extends React.Component {
 
 ```js
 ...
-"react/prefer-stateless-function": [<enabled>, { "ignorePureComponents": <ignorePureComponents> }]
+"react/prefer-stateless-function": [<enabled>, { "ignorePureComponents": <ignorePureComponents>, "subRenderMethods": <subRenderMethods> }]
 ...
 ```
 
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to 0.
 * `ignorePureComponents`: optional boolean set to `true` to ignore components extending from `React.PureComponent` (default to `false`).
+* `subRenderMethods`: optional boolean set to `true` to also warn on methods in React Components that return JSX other than the `render()` method (default to `false`).
 
 ### `ignorePureComponents`
 
@@ -82,6 +84,30 @@ The following pattern is considered a warning because it's not using props or co
 class Foo extends React.PureComponent {
   render() {
     return <div>Bar</div>;
+  }
+}
+```
+
+### `subRenderMethods`
+
+When `true` the rule will warn when you use methods that return JSX in a React Component other than the `render()` method
+
+The following patterns is considered a warning:
+
+```jsx
+class Foo extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {myState: ""}
+  }
+
+  renderFoo() {
+    return <span>{this.state.myState}</span>
+  }
+
+  render() {
+    return <div>{this.renderFoo()}</div>;
   }
 }
 ```

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -35,6 +35,7 @@ module.exports = {
 
   create: Components.detect((context, components, utils) => {
     let propTypesPackageName;
+    let reactPackageName;
 
     function checkValidPropTypeQualfier(node) {
       if (node.name !== 'isRequired') {
@@ -56,7 +57,7 @@ module.exports = {
 
     /* eslint-disable no-use-before-define */
     function checkValidProp(node) {
-      if (!propTypesPackageName || !node) {
+      if ((!propTypesPackageName && !reactPackageName) || !node) {
         return;
       }
 
@@ -124,12 +125,14 @@ module.exports = {
       ImportDeclaration: function(node) {
         if (node.source && node.source.value === 'prop-types') { // import PropType from "prop-types"
           propTypesPackageName = node.specifiers[0].local.name;
-        }
-      },
+        } else if (node.source && node.source.value === 'react') { // import { PropTypes } from "react"
+          reactPackageName = node.specifiers[0].local.name;
 
-      CallExpression: function(node) {
-        if (node.callee.name === 'require' && node.arguments[0].value === 'prop-types') {
-          propTypesPackageName = node.parent.id.name;
+          propTypesPackageName = node.specifiers.length > 1 && (
+            node.specifiers
+              .filter(specifier => specifier.imported && specifier.imported.name === 'PropTypes')
+              .map(specifier => specifier.local.name)
+          );
         }
       },
 

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -34,6 +34,8 @@ module.exports = {
   },
 
   create: Components.detect((context, components, utils) => {
+    let propTypesPackageName;
+
     function checkValidPropTypeQualfier(node) {
       if (node.name !== 'isRequired') {
         context.report({
@@ -54,12 +56,26 @@ module.exports = {
 
     /* eslint-disable no-use-before-define */
     function checkValidProp(node) {
-      if (node && node.type === 'MemberExpression' && node.object.type === 'MemberExpression') {
+      if (!propTypesPackageName || !node) {
+        return;
+      }
+
+      if (
+        node.type === 'MemberExpression' &&
+        node.object.type === 'MemberExpression' &&
+        node.object.object.name === propTypesPackageName
+      ) { // PropTypes.myProp.isRequired
         checkValidPropType(node.object.property);
         checkValidPropTypeQualfier(node.property);
-      } else if (node && node.type === 'MemberExpression' && node.object.type === 'Identifier') {
+      } else if (
+        node.type === 'MemberExpression' &&
+        node.object.type === 'Identifier' &&
+        node.object.name === propTypesPackageName
+      ) { // PropTypes.myProp
         checkValidPropType(node.property);
-      } else if (node && node.type === 'CallExpression') {
+      } else if (
+        node.type === 'CallExpression'
+      ) { // Shapes
         const callee = node.callee;
         if (callee.type === 'MemberExpression' && callee.property.name === 'shape') {
           checkValidPropObject(node.arguments[0]);
@@ -105,6 +121,18 @@ module.exports = {
     }
 
     return {
+      ImportDeclaration: function(node) {
+        if (node.source && node.source.value === 'prop-types') { // import PropType from "prop-types"
+          propTypesPackageName = node.specifiers[0].local.name;
+        }
+      },
+
+      CallExpression: function(node) {
+        if (node.callee.name === 'require' && node.arguments[0].value === 'prop-types') {
+          propTypesPackageName = node.parent.id.name;
+        }
+      },
+
       ClassProperty: function(node) {
         if (!node.static || !utils.isES6Component(node.parent.parent)) {
           return;

--- a/lib/rules/no-typos.js
+++ b/lib/rules/no-typos.js
@@ -77,7 +77,6 @@ module.exports = {
         node.properties.forEach(prop => checkValidProp(prop.value));
       }
     }
-    /* eslint-enable no-use-before-define */
 
     function reportErrorIfClassPropertyCasingTypo(node, propertyName) {
       if (propertyName === 'propTypes' || propertyName === 'contextTypes' || propertyName === 'childContextTypes') {

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -28,6 +28,11 @@ module.exports = {
         ignorePureComponents: {
           default: false,
           type: 'boolean'
+        },
+        // Enable by default when making a new major release.
+        subRenderMethods: {
+          default: false,
+          type: 'boolean'
         }
       },
       additionalProperties: false
@@ -294,6 +299,20 @@ module.exports = {
           return;
         }
         markThisAsUsed(node);
+      },
+
+      // Report non-"render" methods that return JSX
+      MethodDefinition: function(node) {
+        if (
+          utils.isES6Component(node.parent.parent) &&
+          node.key.name !== 'render' &&
+          utils.isReturningJSX(node.value)
+        ) {
+          context.report({
+            node: node,
+            message: 'Method returning JSX should be written as stateless function component'
+          });
+        }
       },
 
       // Mark `this` usage

--- a/lib/rules/prefer-stateless-function.js
+++ b/lib/rules/prefer-stateless-function.js
@@ -96,8 +96,7 @@ module.exports = {
      * @see ESLint no-useless-constructor rule
      * @param {ASTNode} ctorParam - A node to check.
      * @param {ASTNode} superArg - A node to check.
-     * @returns {boolean} `true` if the nodes are identifiers which have the same
-     *      name.
+     * @returns {boolean} `true` if the nodes are identifiers which have the same name.
      */
     function isValidIdentifierPair(ctorParam, superArg) {
       return (

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -341,6 +341,34 @@ ruleTester.run('no-typos', rule, {
     code: `
       import PropTypes from "prop-types";
       class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.oneOf([
+          'hello',
+          'hi'
+        ])
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: PropTypes.string,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.shape({
+          d: PropTypes.string,
+          e: PropTypes.number.isRequired,
+        }).isRequired
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
       Component.contextTypes = {
         a: PropTypes.string,
         b: PropTypes.string.isRequired,
@@ -367,26 +395,22 @@ ruleTester.run('no-typos', rule, {
     parserOptions: parserOptions
   }, {
     code: `
-      const PropTypes = require('prop-types');
-      const MyPropTypes = require('lib/my-prop-types')
+      import PropTypes from "prop-types"
+      import * as MyPropTypes from 'lib/my-prop-types'
       class Component extends React.Component {};
       Component.propTypes = {
-        a: PropTypes.string,
-        b: MyPropTypes.MYSTRING,
-        c: MyPropTypes.MYSTRING.isRequired,
+        b: PropTypes.string,
+        a: MyPropTypes.MYSTRING,
       }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
     code: `
-      const RealPropTypes = require('prop-types');
-      const MyPropTypes = require('lib/my-prop-types')
+      import CustomReact from "react"
       class Component extends React.Component {};
       Component.propTypes = {
-        a: RealPropTypes.string,
-        b: MyPropTypes.MYSTRING,
-        c: MyPropTypes.MYSTRING.isRequired,
+        b: CustomReact.PropTypes.string,
       }
    `,
     parser: 'babel-eslint',
@@ -857,47 +881,16 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
-      const PropTypes = require('prop-types');
+      import RealReactDifferentName from "react"
       class Component extends React.Component {};
-      Component.childContextTypes = {
-        a: PropTypes.bools,
-        b: PropTypes.Array,
-        c: PropTypes.function,
-        d: PropTypes.objectof,
+      Component.propTypes = {
+        b: RealReactDifferentName.PropTypes.STRING,
       }
-    `,
+   `,
     parser: 'babel-eslint',
     parserOptions: parserOptions,
     errors: [{
-      message: 'Typo in declared prop type: bools'
-    }, {
-      message: 'Typo in declared prop type: Array'
-    }, {
-      message: 'Typo in declared prop type: function'
-    }, {
-      message: 'Typo in declared prop type: objectof'
-    }]
-  }, {
-    code: `
-      const RealPropTypes = require('prop-types');
-      class Component extends React.Component {};
-      Component.childContextTypes = {
-        a: RealPropTypes.bools,
-        b: RealPropTypes.Array,
-        c: RealPropTypes.function,
-        d: RealPropTypes.objectof,
-      }
-    `,
-    parser: 'babel-eslint',
-    parserOptions: parserOptions,
-    errors: [{
-      message: 'Typo in declared prop type: bools'
-    }, {
-      message: 'Typo in declared prop type: Array'
-    }, {
-      message: 'Typo in declared prop type: function'
-    }, {
-      message: 'Typo in declared prop type: objectof'
+      message: 'Typo in prop type chain qualifier: STRING'
     }]
   }]
 });

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -260,81 +260,134 @@ ruleTester.run('no-typos', rule, {
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-     Component.propTypes = {
-       a: PropTypes.number.isRequired
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.number.isRequired
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-     Component.propTypes = {
-       e: PropTypes.shape({
-         ea: PropTypes.string,
-       })
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.propTypes = {
+        e: PropTypes.shape({
+          ea: PropTypes.string,
+        })
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-     Component.propTypes = {
-       a: PropTypes.string,
-       b: PropTypes.string.isRequired,
-       c: PropTypes.shape({
-         d: PropTypes.string,
-         e: PropTypes.number.isRequired,
-       }).isRequired
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.string,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.shape({
+          d: PropTypes.string,
+          e: PropTypes.number.isRequired,
+        }).isRequired
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-    Component.propTypes = {
-       a: PropTypes.oneOfType([
-         PropTypes.string,
-         PropTypes.number
-       ])
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.oneOfType([
+          PropTypes.string,
+          PropTypes.number
+        ])
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-    Component.propTypes = {
-       a: PropTypes.oneOf([
-         'hello',
-         'hi'
-       ])
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.oneOf([
+          'hello',
+          'hi'
+        ])
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-     Component.childContextTypes = {
-       a: PropTypes.string,
-       b: PropTypes.string.isRequired,
-       c: PropTypes.shape({
-         d: PropTypes.string,
-         e: PropTypes.number.isRequired,
-       }).isRequired
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: PropTypes.string,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.shape({
+          d: PropTypes.string,
+          e: PropTypes.number.isRequired,
+        }).isRequired
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
   }, {
-    code: `class Component extends React.Component {};
-     Component.contextTypes = {
-       a: PropTypes.string,
-       b: PropTypes.string.isRequired,
-       c: PropTypes.shape({
-         d: PropTypes.string,
-         e: PropTypes.number.isRequired,
-       }).isRequired
-     }
+    code: `
+      import PropTypes from "prop-types";
+      class Component extends React.Component {};
+      Component.contextTypes = {
+        a: PropTypes.string,
+        b: PropTypes.string.isRequired,
+        c: PropTypes.shape({
+          d: PropTypes.string,
+          e: PropTypes.number.isRequired,
+        }).isRequired
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: `
+      import PropTypes from 'prop-types'
+      import * as MyPropTypes from 'lib/my-prop-types'
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.string,
+        b: MyPropTypes.MYSTRING,
+        c: MyPropTypes.MYSTRING.isRequired,
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: `
+      const PropTypes = require('prop-types');
+      const MyPropTypes = require('lib/my-prop-types')
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: PropTypes.string,
+        b: MyPropTypes.MYSTRING,
+        c: MyPropTypes.MYSTRING.isRequired,
+      }
+   `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions
+  }, {
+    code: `
+      const RealPropTypes = require('prop-types');
+      const MyPropTypes = require('lib/my-prop-types')
+      class Component extends React.Component {};
+      Component.propTypes = {
+        a: RealPropTypes.string,
+        b: MyPropTypes.MYSTRING,
+        c: MyPropTypes.MYSTRING.isRequired,
+      }
    `,
     parser: 'babel-eslint',
     parserOptions: parserOptions
@@ -689,6 +742,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
           a: PropTypes.Number.isRequired
@@ -701,6 +755,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
           a: PropTypes.number.isrequired
@@ -713,6 +768,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
           a: PropTypes.Number
@@ -725,6 +781,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
         a: PropTypes.shape({
@@ -740,6 +797,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
         a: PropTypes.oneOfType([
@@ -755,6 +813,7 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.propTypes = {
         a: PropTypes.bools,
@@ -776,12 +835,57 @@ ruleTester.run('no-typos', rule, {
     }]
   }, {
     code: `
+      import PropTypes from "prop-types";
       class Component extends React.Component {};
       Component.childContextTypes = {
         a: PropTypes.bools,
         b: PropTypes.Array,
         c: PropTypes.function,
         d: PropTypes.objectof,
+      }
+    `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
+  }, {
+    code: `
+      const PropTypes = require('prop-types');
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: PropTypes.bools,
+        b: PropTypes.Array,
+        c: PropTypes.function,
+        d: PropTypes.objectof,
+      }
+    `,
+    parser: 'babel-eslint',
+    parserOptions: parserOptions,
+    errors: [{
+      message: 'Typo in declared prop type: bools'
+    }, {
+      message: 'Typo in declared prop type: Array'
+    }, {
+      message: 'Typo in declared prop type: function'
+    }, {
+      message: 'Typo in declared prop type: objectof'
+    }]
+  }, {
+    code: `
+      const RealPropTypes = require('prop-types');
+      class Component extends React.Component {};
+      Component.childContextTypes = {
+        a: RealPropTypes.bools,
+        b: RealPropTypes.Array,
+        c: RealPropTypes.function,
+        d: RealPropTypes.objectof,
       }
     `,
     parser: 'babel-eslint',

--- a/tests/lib/rules/no-typos.js
+++ b/tests/lib/rules/no-typos.js
@@ -879,18 +879,5 @@ ruleTester.run('no-typos', rule, {
     }, {
       message: 'Typo in declared prop type: objectof'
     }]
-  }, {
-    code: `
-      import RealReactDifferentName from "react"
-      class Component extends React.Component {};
-      Component.propTypes = {
-        b: RealReactDifferentName.PropTypes.STRING,
-      }
-   `,
-    parser: 'babel-eslint',
-    parserOptions: parserOptions,
-    errors: [{
-      message: 'Typo in prop type chain qualifier: STRING'
-    }]
   }]
 });

--- a/tests/lib/rules/prefer-stateless-function.js
+++ b/tests/lib/rules/prefer-stateless-function.js
@@ -305,6 +305,33 @@ ruleTester.run('prefer-stateless-function', rule, {
         }
       `,
       parser: 'babel-eslint'
+    }, {
+      // Methods that do not return JSX are still valid
+      code: `
+        class Foo extends React.Component {
+          renderString() {
+            return "X";
+          }
+
+          renderNumber() {
+            return 42;
+          }
+
+          getSomeData() {
+            return {}
+          }
+
+          render() {
+            return (
+              <div>
+                {this.renderString()}
+                {this.renderNumber()}
+                {this.getSomeData()}
+              </div>
+            )
+          }
+        }
+      `
     }
   ],
 
@@ -594,6 +621,22 @@ ruleTester.run('prefer-stateless-function', rule, {
       `,
       errors: [{
         message: 'Component should be written as a pure function'
+      }]
+    }, {
+      // Sub-render method that returns JSX
+      code: `
+        class Foo extends React.Component {
+          renderFoo() {
+            return <div />;
+          }
+
+          render() {
+            return this.renderFoo();
+          }
+        }
+      `,
+      errors: [{
+        message: 'Method returning JSX should be written as stateless function component'
       }]
     }
   ]


### PR DESCRIPTION
This is simply a rebase of @jseminck's branch, plus the removal of the
lingering failing test.

I removed the failing test because I believe it's a very small corner case
that should not block the resolution of this issue, which seems to affect
a lot of people and limits our ability to keep our components' proptypes DRY.

If it's determined that this corner case *should* be handled, I suggest creating
a new issue to track just that case.

Closes #1389.